### PR TITLE
Use only cjs inside src folder

### DIFF
--- a/src/utils/schema.js
+++ b/src/utils/schema.js
@@ -1,4 +1,4 @@
-import { createHash } from "crypto";
+const { createHash } = require("crypto");
 
 const { gql, makeExecutableSchema } = require("apollo-server");
 const { printSchema } = require("graphql");


### PR DESCRIPTION
Hi, I am trying to use the `federation-subscription-tools` package with TypeScript, but because it mixes esm with cjs, we can't configure our tooling to build the application. So, I think that would be nice to only use cjs inside the src folder.

```
/home/gtkatakura/projects/vtex/instore-core/node_modules/federation-subscription-tools/src/utils/schema.js:1
import { createHash } from "crypto";
^^^^^^

SyntaxError: Cannot use import statement outside a module
    at wrapSafe (internal/modules/cjs/loader.js:979:16)
    at Module._compile (internal/modules/cjs/loader.js:1027:27)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
    at Module.load (internal/modules/cjs/loader.js:928:32)
    at Function.Module._load (internal/modules/cjs/loader.js:769:14)
    at Module.require (internal/modules/cjs/loader.js:952:19)
    at require (internal/modules/cjs/helpers.js:88:18)
    at Object.<anonymous> (/home/gtkatakura/projects/vtex/instore-core/node_modules/federation-subscription-tools/src/index.js:8:5)
    at Module._compile (internal/modules/cjs/loader.js:1063:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
[nodemon] app crashed - waiting for file changes before starting...

```