### PR TITLE
Fix react app URLs

### DIFF
--- a/example/react-app/.env.sample
+++ b/example/react-app/.env.sample
@@ -1,2 +1,2 @@
-REACT_APP_GRAPHQL_URL=http://localhost:4000/graphql
-REACT_APP_SOCKETIO_URL=http://localhost:5000
+REACT_APP_GATEWAY_API_URL=http://localhost:4000/graphql
+REACT_APP_SUBSCRIPTIONS_API_URL=ws://localhost:5000/graphql


### PR DESCRIPTION
Hey Mandi.

Once containers do start, looks like env vars that define gateway & subscription URLs are outdated.
This seems to fix it (at least new error is different from this one :D)

<img width="1144" alt="Screenshot 2021-07-19 at 21 19 48" src="https://user-images.githubusercontent.com/445122/126208117-09b0a25d-eefb-45a3-beaf-cd6677f1ddc6.png">
