### PR TITLE
fix: used require instead of import

### DIFF
--- a/src/utils/schema.js
+++ b/src/utils/schema.js
@@ -1,5 +1,4 @@
-import { createHash } from "crypto";
-
+const { createHash } = require("crypto");
 const { gql, makeExecutableSchema } = require("apollo-server");
 const { printSchema } = require("graphql");
 


### PR DESCRIPTION
`SyntaxError: Cannot use import statement outside a module` is thrown when using TS in main project. Therefore switch to require is the simplest workaround.