### PR TITLE
Added typings, fixed import module error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "federation-subscription-tools",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A set of demonstration utilities to facilitate GraphQL subscription usage alongside a federated data graph.",
   "main": "src/index.js",
   "typings": "src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "description": "A set of demonstration utilities to facilitate GraphQL subscription usage alongside a federated data graph.",
   "main": "src/index.js",
+  "typings": "src/index.d.ts",
   "keywords": [],
   "author": "",
   "license": "ISC",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,64 @@
+declare module 'federation-subscription-tools' {
+  import { DataSource } from 'apollo-datasource'
+  import type {
+      ApolloLink,
+      FetchResult,
+  } from 'apollo-link'
+  import type { DocumentNode, GraphQLSchema } from 'graphql'
+
+  type Muteable<T> = { -readonly [P in keyof T]: T[P] }
+
+  export type MuteableRequest = Muteable<Request>
+
+  export class GatewayDataSource extends DataSource {
+      constructor(gatewayUrl: string)
+
+      willSendRequest(request: Muteable<Request>): void
+
+      composeLinks(): ApolloLink
+
+      didEncounterError(error: unknown): void
+
+      onErrorLink(): ApolloLink
+
+      onRequestLink(): ApolloLink
+
+      resolveUri(): string
+
+      // Utils that support diffing payload fields with operation field selections
+
+      addDelimiter(a: string, b: string): string
+
+      isObject(value: unknown): boolean
+
+      isFieldObject(object: unknown): boolean
+
+      fieldPathsAsStrings(object: unknown): string
+
+      fieldPathsAsMapFromResolveInfo(resolveInfo: unknown): Record<string, unknown>
+
+      buildSelection(selection: unknown, pathString: unknown, pathParts: unknown, fieldPathMap: unknown, index: unknown): string
+
+      buildNonPayloadSelections(payload: unknown, info: unknown): string
+
+      mergeFieldData(payloadFieldData: unknown, nonPayloadFieldData: unknown): Record<string, unknown>
+
+      query(query: unknown, options: unknown): Promise<FetchResult>
+  }
+
+  export function addGatewayDataSourceToSubscriptionContext(context: unknown, gatewayDataSource: GatewayDataSource):
+    { dataSources: { gatewayApi: GatewayDataSource } }
+
+  export function makeSubscriptionSchema(options: {
+      gatewaySchema: GraphQLSchema,
+      resolvers: unknown,
+      typeDefs: DocumentNode,
+  }): GraphQLSchema
+
+  export function getGatewayApolloConfig(key: string, graphVariant: string): {
+    graphId: string
+    graphVariant: string
+    key: string
+    keyHash: string
+  }
+}

--- a/src/utils/schema.js
+++ b/src/utils/schema.js
@@ -1,5 +1,4 @@
-import { createHash } from "crypto";
-
+const { createHash } = require("crypto");
 const { gql, makeExecutableSchema } = require("apollo-server");
 const { printSchema } = require("graphql");
 


### PR DESCRIPTION
- added typings
- switched import to require because of `SyntaxError: Cannot use import statement outside a module` error when using TS in main project
- version bump to 0.1.1