### PR TITLE
Uses ApolloServer

### DIFF
--- a/example/react-app/.env.sample
+++ b/example/react-app/.env.sample
@@ -1,2 +1,2 @@
-REACT_APP_GRAPHQL_URL=http://localhost:4000/graphql
-REACT_APP_SOCKETIO_URL=http://localhost:5000
+REACT_APP_GATEWAY_API_URL=http://localhost:4000/graphql
+REACT_APP_SUBSCRIPTIONS_API_URL=ws://localhost:5000

--- a/example/subscriptions-server/package.json
+++ b/example/subscriptions-server/package.json
@@ -11,14 +11,16 @@
   "license": "ISC",
   "dependencies": {
     "@apollo/gateway": "^0.25.0",
+    "apollo-server-express": "^2.25.2",
     "dotenv": "^8.2.0",
     "esm": "^3.2.25",
+    "express": "^4.17.1",
     "graphql": "^15.5.0",
     "graphql-redis-subscriptions": "^2.3.1",
     "graphql-tag": "^2.11.0",
     "graphql-ws": "^4.2.0",
     "ioredis": "^4.19.4",
     "nodemon": "^2.0.7",
-    "ws": "^7.4.4"
+    "ws": "^8.2.3"
   }
 }


### PR DESCRIPTION
This PR updates the subscription-server example to use Apollo Server, work derived from https://github.com/enisdenjo/graphql-ws#apollo-server-express

With this update you can now connect to ws://localhost:5000/graphql and open http://localhost:5000/graphql to explore the available subscriptions. It also enables the use of tools like Graphql Code Generator. Lastly if Apollo Server updates to support graphql-ws, which they have said they plan on supporting in the future (quoted below), we would be able to subscribe to these right in this Playground 

> Note that the subscriptions-transport-ws library is not actively maintained. An alternative, actively-maintained graphql-ws package exists, **which we intend to support in a future release**. . . At the time of release of Apollo Server 3, the graphql-ws protocol is not yet supported by GraphQL Playground or the Apollo Studio Explorer.

A drawback to this implementation is that the Playground will show the entire schema, including everything fetched from the gateway-server. We can avoid this by passing in just the typeDefs when we instantiate the ApolloServer, but ApolloServer requires at least one Query, and since this is for subscriptions only, it fails. We also seemingly can't just define an empty query because then makeSubscriptionSchema will fail. I'm not sure what the best approach would be here, I'll be trying out a few more things, I'd greatly welcome any advice